### PR TITLE
Fixed obsolete dependency links in building scripts

### DIFF
--- a/admin/builders/centos64_build.sh
+++ b/admin/builders/centos64_build.sh
@@ -55,7 +55,7 @@ fi
 cmake_bin="${src_dir}/${cm}/bin/cmake"
 
 # download, compile and link xerces
-xer=xerces-c-3.1.1
+xer=xerces-c-3.1.2
 if [ -e ${xer}.tar.gz ]; then
   echo "  XercesC has been installed previously, remove if you want a clean install"
 else

--- a/admin/builders/fedora64_build.sh
+++ b/admin/builders/fedora64_build.sh
@@ -48,8 +48,7 @@ sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/parsing.txx
 sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/stream-extraction.hxx
 
 # download, compile and link xerces
-xer=xerces-c-3.1.1
-
+xer=xerces-c-3.1.2
 wget --quiet http://apache.mirrors.spacedump.net//xerces/c/3/sources/${xer}.tar.gz
 
 mkdir ${build_dir}

--- a/admin/builders/mingw32_build.sh
+++ b/admin/builders/mingw32_build.sh
@@ -47,7 +47,7 @@ sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/parsing.txx
 sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/stream-extraction.hxx
 
 # download, compile and link xerces
-xer=xerces-c-3.1.1
+xer=xerces-c-3.1.2
 
 wget --quiet http://apache.mirrors.spacedump.net//xerces/c/3/sources/${xer}.tar.gz
 

--- a/admin/builders/mingw64_build.sh
+++ b/admin/builders/mingw64_build.sh
@@ -48,7 +48,7 @@ sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/parsing.txx
 sed -i 's/ push_back/ this->push_back/g' ${xsd}/libxsd/xsd/cxx/tree/stream-extraction.hxx
 
 # download, compile and link xerces
-xer=xerces-c-3.1.1
+xer=xerces-c-3.1.2
 
 wget --quiet http://apache.mirrors.spacedump.net//xerces/c/3/sources/${xer}.tar.gz
 

--- a/admin/builders/nativew32_build.bat
+++ b/admin/builders/nativew32_build.bat
@@ -108,7 +108,7 @@ set PATH=%PATH%;%LIBXML_DIR%\bin
 
 ::: Needed for converters package and xml support in percolator package :::
 set XERCES_DIR=%INSTALL_DIR%\xerces-c-3.1.1-x86-windows-vc-10.0
-set XERCES_URL=http://apache.mirrors.spacedump.net/xerces/c/3/binaries/xerces-c-3.1.1-x86-windows-vc-10.0.zip
+set XERCES_URL=http://archive.apache.org/dist/xerces/c/3/binaries/xerces-c-3.1.1-x86-windows-vc-10.0.zip
 if not exist "%XERCES_DIR%" (
   echo Downloading and installing Xerces-C
   PowerShell "(new-object System.Net.WebClient).DownloadFile('%XERCES_URL%','%INSTALL_DIR%\xerces.zip')"

--- a/admin/builders/nativew64_build.bat
+++ b/admin/builders/nativew64_build.bat
@@ -110,7 +110,7 @@ set PATH=%PATH%;%LIBXML_DIR%\bin
 
 ::: Needed for converters package and xml support in percolator package :::
 set XERCES_DIR=%INSTALL_DIR%\xerces-c-3.1.1-x86_64-windows-vc-10.0
-set XERCES_URL=http://apache.mirrors.spacedump.net/xerces/c/3/binaries/xerces-c-3.1.1-x86_64-windows-vc-10.0.zip
+set XERCES_URL=http://archive.apache.org/dist/xerces/c/3/binaries/xerces-c-3.1.1-x86_64-windows-vc-10.0.zip
 if not exist "%XERCES_DIR%" (
   echo Downloading and installing Xerces-C
   PowerShell "(new-object System.Net.WebClient).DownloadFile('%XERCES_URL%','%INSTALL_DIR%\xerces.zip')"
@@ -128,23 +128,25 @@ if not exist "%XSD_DIR%" (
 
 ::: Needed for converters package :::
 set SQLITE_DIR=%INSTALL_DIR%\sqlite3_x64
-set SQLITE_SRC_URL=http://www.sqlite.org/snapshot/sqlite-amalgamation32k-201409200035.zip
-set SQLITE_DLL_URL=http://www.sqlite.org/snapshot/sqlite-dll-win64-x64-201409200035.zip
+set SQLITE_SRC_URL=http://sqlite.org/2015/sqlite-amalgamation-3080803.zip
+set SQLITE_DLL_URL=http://system.data.sqlite.org/blobs/1.0.96.0/sqlite-netFx45-binary-x64-2012-1.0.96.0.zip
 if not exist "%SQLITE_DIR%" (
   echo Downloading and installing SQLite3
   PowerShell "(new-object System.Net.WebClient).DownloadFile('%SQLITE_SRC_URL%','%INSTALL_DIR%\sqlite_src.zip')"
   PowerShell "(new-object System.Net.WebClient).DownloadFile('%SQLITE_DLL_URL%','%INSTALL_DIR%\sqlite_dll.zip')"
-  %ZIP_EXE% x "%INSTALL_DIR%\sqlite_src.zip" -o"%SQLITE_DIR%\src" > NUL
+  %ZIP_EXE% x "%INSTALL_DIR%\sqlite_src.zip" -o"%SQLITE_DIR%" > NUL
   %ZIP_EXE% x "%INSTALL_DIR%\sqlite_dll.zip" -o"%SQLITE_DIR%" > NUL
   
   ::: Generate lib from dll
+  cd /D "%SQLITE_DIR%"
+  ren sqlite-amalgamation-3080803 src
+  ren SQLite.Interop.dll sqlite3.dll
   setlocal enableDelayedExpansion
   set DLL_BASE=%SQLITE_DIR%\sqlite3
   set DEF_FILE=!DLL_BASE!.def
   set write=0
   echo EXPORTS> "!DEF_FILE!"
   for /f "usebackq tokens=4" %%i in (`dumpbin /exports "!DLL_BASE!.dll"`) do if "!write!"=="1" (echo %%i >> "!DEF_FILE!") else (if %%i==name set write=1)
-  cd /D "%SQLITE_DIR%"
   lib /DEF:"!DEF_FILE!" /MACHINE:X64
   endlocal
 )

--- a/admin/vagrant/batch.sh
+++ b/admin/vagrant/batch.sh
@@ -23,7 +23,11 @@ if [[ $? -eq 0 ]]; then
   echo "Building of Fedora binaries succeeded"
 fi
 
+echo "Building CentOS binaries"
+./manager.sh -p centos > centos_output.txt 2>&1
+if [[ $? -eq 0 ]]; then
+  echo "Building of CentOS binaries succeeded"
+fi
 
-
-#./manager.sh -p w32 > w32_output.txt 2>&1
-#./manager.sh -p w64 > w64_output.txt 2>&1
+#./manager.sh -p w32 > w32_output.txt 2>&1 # MINGW32
+#./manager.sh -p w64 > w64_output.txt 2>&1 # MINGW64


### PR DESCRIPTION
Download links to Xerces version 3.1.1 were no longer valid (affects Windows, CentOS and Fedora builds), updated to v3.1.2 for CentOS and Fedora and used archived 3.1.1 versions for windows.
Download link for Sqlite3 DLL on windows 64 bit was no longer valid, updated with DLL normally used in .NET applications (works after simple renaming).