### PR TITLE
Fixed osx build

### DIFF
--- a/CommonCMake.txt
+++ b/CommonCMake.txt
@@ -43,7 +43,7 @@ endfunction()
 
 
 # VERSION AND NAMESPACES
-set(CPACK_PACKAGE_VERSION_MAJOR "0")
+set(CPACK_PACKAGE_VERSION_MAJOR "3")
 set(CPACK_PACKAGE_VERSION_MINOR "00")
 set(CPACK_PACKAGE_VERSION_PATCH "0")
 set(PIN_VERSION_MAJOR "1")
@@ -62,7 +62,7 @@ ELSE(MSVC)
   set(XML_REL_PATH "share/xml/percolator/")
 ENDIF(MSVC)
 
-IF(MINGW OR WIN32) 
+IF(MINGW OR WIN32)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll" ${CMAKE_FIND_LIBRARY_SUFFIXES})
     set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/lib/include)
     set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/lib/lib)
@@ -81,12 +81,12 @@ set(POUT_SCHEMA_LOCATION "xml-pout-${POUT_VERSION_MAJOR}-${POUT_VERSION_MINOR}/"
 IF(MINGW)
   IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
     SET(MINGW64 1)
-    SET(MINGW_PATH /usr/x86_64-w64-mingw32/sys-root/mingw/)  
-    SET(MINGW_PACK_NAME win64)  
+    SET(MINGW_PATH /usr/x86_64-w64-mingw32/sys-root/mingw/)
+    SET(MINGW_PACK_NAME win64)
   ELSE()
     SET(MINGW32 1)
-    SET(MINGW_PATH /usr/i686-w64-mingw32/sys-root/mingw/)  
-    SET(MINGW_PACK_NAME win32)  
+    SET(MINGW_PATH /usr/i686-w64-mingw32/sys-root/mingw/)
+    SET(MINGW_PACK_NAME win32)
   ENDIF()
 ENDIF(MINGW)
 
@@ -110,11 +110,11 @@ endif()
 
 # Link Boost static and single threaded
 set(Boost_USE_STATIC_LIBS   ON)
-set(Boost_USE_MULTITHREADED OFF)  
+set(Boost_USE_MULTITHREADED OFF)
 
 set(BOOST_MIN_VERSION "1.46.0")
-set(Boost_ADDITIONAL_VERSIONS "1.36" "1.36.0" "1.41" "1.41.0" "1.39" "1.39.0" "1.42.0" "1.42" "1.43.0" 
-			       "1.43." "1.44.0" "1.44.0" "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47" 
+set(Boost_ADDITIONAL_VERSIONS "1.36" "1.36.0" "1.41" "1.41.0" "1.39" "1.39.0" "1.42.0" "1.42" "1.43.0"
+			       "1.43." "1.44.0" "1.44.0" "1.45.0" "1.45" "1.46.0" "1.46" "1.47.0" "1.47"
 			       "1.48" "1.48.0" "1.49" "1.49.0" "1.50.0" "1.50" "1.51.0" "1.51")
 
 ###############################################################################
@@ -146,7 +146,7 @@ endif()
 
 if(MSVC)
   add_definitions (/MP /D _CRT_SECURE_NO_WARNINGS /D _CRT_NONSTDC_NO_DEPRECATE)
-  # CMake automatically configures VS to use multi threading, 
+  # CMake automatically configures VS to use multi threading,
   # if boost would use single threading, the auto-linking process of boost would fail.
   set(Boost_USE_MULTITHREADED ON)
 endif(MSVC)

--- a/admin/builders/_urls_and_file_names_.sh
+++ b/admin/builders/_urls_and_file_names_.sh
@@ -1,0 +1,13 @@
+# Centralized place for urls and files for all builders ... (maybe ;)
+# please do not change compression type in urls, since decompression is
+# hardcoded in the respective buiding scripts
+
+#
+# macOS
+#
+# -- xsd --
+mac_os_xsd='xsd-3.3.0-i686-macosx'
+mac_os_xsd_url='http://www.codesynthesis.com/download/xsd/3.3/macosx/i686/'${mac_os_xsd}'.tar.bz2'
+# -- xerces --
+mac_os_xerces='xerces-c-3.1.4'
+mac_os_xerces_url='http://apache.mirrors.spacedump.net/xerces/c/3/sources/'${mac_os_xerces}'.tar.gz'

--- a/admin/builders/osx_build.sh
+++ b/admin/builders/osx_build.sh
@@ -26,6 +26,22 @@ if [[ ! -d /Applications/XCode.app ]]
     exit 1
 fi
 
+if [[ ! -d /Applications/PackageMaker.app ]]
+  then
+    echo "Apple developer PackageManager is required and expected in the "
+    echo "/Applications folder. If you have moved it elsewhere, please change this script"
+    echo ""
+    echo "It is part of the Auxiliary tools for XCode - Late July 2012"
+    echo "Yes, 2012! since then Apple moved to the app store and requires"
+    echo "packages and dmgs to be build differently. "
+    echo "However, the old packagemaker still works with 10.11"
+    echo
+    echo "You can find it here: "
+    echo "http://adcdownload.apple.com/Developer_Tools/auxiliary_tools_for_xcode__late_july_2012/xcode44auxtools6938114a.dmg"
+    echo ""
+    exit 1
+fi
+exit 1
 package_manager_installed=true
 if [[ -d /opt/local/var/macports ]]
   then


### PR DESCRIPTION
Hi Percolator team,

I fixed the osx_build.sh again and included now a check for the very old (but still available) Packagemanager.app that is required to build the package/.dmg (at least the way you do it). If it is not found the installation script shows where to get it.  

Additionally, I added a file "_urls_and_file_names_.sh" that contains all urls and file names; see it as an effort to centralize the urls so one does not have to fix every installation script ;) 

Cheers and thanks for the new percolator version 3!

.c