### PR TITLE
Fixes for builds on OS X and Windows

### DIFF
--- a/src/ProteinProbEstimator.cpp
+++ b/src/ProteinProbEstimator.cpp
@@ -267,7 +267,7 @@ void ProteinProbEstimator::getTPandPFfromPeptides(double psm_threshold,
    * This creates sometimes a difference in the number of TP and FP proteins between percolator and Mayus 
    * which causes a slight difference in the estimated protein FDR
    */
-  for (std::map<std::string,ProteinScoreHolder*>::const_iterator it = proteins_.begin();
+  for (std::map<const std::string,ProteinScoreHolder*>::const_iterator it = proteins_.begin();
        it != proteins_.end(); it++) {
     unsigned num_target_confident = 0;
     unsigned num_decoy_confident = 0;

--- a/src/picked_protein/Database.cpp
+++ b/src/picked_protein/Database.cpp
@@ -25,6 +25,8 @@
 #include <iostream>
 
 #ifdef _MSC_VER
+
+namespace PercolatorCrux {
 /*********************************************************
  This function replaces the GNU extension of the same name.
  Reads a line from the given stream.
@@ -87,6 +89,7 @@ int getline(char **lineptr, size_t *n, FILE *stream) {
     // Some sort of read error
     return -1;
   }
+}
 }
 #endif
 


### PR DESCRIPTION
Hi, this pull request has two small fixes for building Percolator on OS X and Windows. 

The change to src/ProteinProbEstimator.cpp was accepted in a previous pull request, but the change apparently was lost in a recent commit. It fixes a const correctness issue that upsets clang on OS X.

The changes to src/picked_protein/Database.cpp fixes an issue in the Windows build. The 'getline' function is only compiled on Windows. The function declaration in Database.h is inside the new PercolateorCrux  so the body of the function needs to be too.

Thanks!

Charles