### PR TITLE
Fix a bug that ERRORLEVEL won't be set to 0

### DIFF
--- a/admin/builders/nativew64_build.bat
+++ b/admin/builders/nativew64_build.bat
@@ -8,6 +8,8 @@ if %ERRORLEVEL% EQU 0 (
   set MSVC_VER=14
 )
 
+set ERRORLEVEL=0
+
 :: fall back to VS2013 is available
 if %MSVC_VER% EQU 0 (
   REG QUERY HKEY_CLASSES_ROOT\VisualStudio.DTE.12.0 > nul 2> nul


### PR DESCRIPTION
ERROELEVEL won't be set to 0 even though "REG QUERY HKEY_CLASSES_ROOT\VisualStudio.DTE.12.0 > nul 2> nul" has no error.