### PR TITLE
Supporting the modifications surrounded by "(" and ")". Related to ##222

### DIFF
--- a/src/PSMDescription.cpp
+++ b/src/PSMDescription.cpp
@@ -54,6 +54,15 @@ std::string PSMDescription::removePTMs(const string& peptide) {
       } else {
         peptideSequence.erase(ix--, posEnd + 1);
       }
+    } else if (peptideSequence[ix] == '(') {
+      size_t posEnd = peptideSequence.substr(ix).find_first_of(')');
+      if (posEnd == string::npos) {
+        ostringstream temp;
+        temp << "Error : Peptide sequence " << peptide << " contains an invalid modification" << endl;
+        throw MyException(temp.str());
+      } else {
+        peptideSequence.erase(ix--, posEnd + 1);
+      }
     }
   }
   return peptide.substr(0,1) + std::string(".") + peptideSequence + std::string(".") + peptide.substr(peptide.size() - 1,1);

--- a/src/converters/Reader.cpp
+++ b/src/converters/Reader.cpp
@@ -444,6 +444,15 @@ std::string Reader::removePTMs(const string& peptide, std::map<char,int>& ptmMap
         } else {
           peptideSequence.erase(ix--, posEnd + 1);
         }
+      } else if (peptideSequence[ix] == '(') {
+        size_t posEnd = peptideSequence.substr(ix).find_first_of(')');
+        if (posEnd == string::npos) {
+          ostringstream temp;
+          temp << "Error : Peptide sequence " << peptide << " contains an invalid modification" << endl;
+          throw MyException(temp.str());
+        } else {
+          peptideSequence.erase(ix--, posEnd + 1);
+        }
       } else if (ptmMap.count(peptideSequence[ix]) > 0) {
 	      peptideSequence.erase(ix--,1);
       } else {
@@ -476,6 +485,15 @@ unsigned int Reader::peptideLength(const string& pep) {
       } else {
         pos += posEnd;
       }
+    } else if (pep.at(pos) == '(') {
+      size_t posEnd = pep.substr(pos).find_first_of(')');
+      if (posEnd == string::npos) {
+        ostringstream temp;
+        temp << "Error : Peptide sequence " << pep << " contains an invalid modification" << endl;
+        throw MyException(temp.str());
+      } else {
+        pos += posEnd;
+      }
     }
   }
   return len;
@@ -489,6 +507,16 @@ unsigned int Reader::cntPTMs(const string& pep, std::map<char,int>& ptmMap) {
       ++len;
     } else if (pep.at(pos) == '[') {
       size_t posEnd = pep.substr(pos).find_first_of(']');
+      if (posEnd == string::npos) {
+        ostringstream temp;
+        temp << "Error : Peptide sequence " << pep << " contains an invalid modification" << endl;
+        throw MyException(temp.str());
+      } else {
+        ++len;
+        pos += posEnd;
+      }
+    } else if (pep.at(pos) == '(') {
+      size_t posEnd = pep.substr(pos).find_first_of(')');
       if (posEnd == string::npos) {
         ostringstream temp;
         temp << "Error : Peptide sequence " << pep << " contains an invalid modification" << endl;

--- a/src/converters/SqtReader.cpp
+++ b/src/converters/SqtReader.cpp
@@ -163,6 +163,12 @@ void SqtReader::readPSM(bool isDecoy, const std::string &in,int match,
         std::auto_ptr< percolatorInNs::freeMod > fm_p (new percolatorInNs::freeMod(modAcc));
         mod_p->freeMod(fm_p);
         peptideSequence.erase(ix--, posEnd + 1);
+      } else if (peptideSequence[ix] == '(') {
+        unsigned int posEnd = peptideSequence.substr(ix).find_first_of(')');
+        std::string modAcc = peptideSequence.substr(ix + 1, posEnd - 1);
+        std::auto_ptr< percolatorInNs::freeMod > fm_p (new percolatorInNs::freeMod(modAcc));
+        mod_p->freeMod(fm_p);
+        peptideSequence.erase(ix--, posEnd + 1);
       } else {
         int accession = ptmMap[peptideSequence[ix]];
         std::auto_ptr< percolatorInNs::uniMod > um_p (new percolatorInNs::uniMod(accession));


### PR DESCRIPTION
I added some codes to support "()" style modification. I tested it with one pin file and changed all the "[]" to "()" style. Percolator produced the same result. Please find all the files in the attachment.
[dev.zip](https://github.com/percolator/percolator/files/2361170/dev.zip)
