### PR TITLE
Fix TabReader error handling

### DIFF
--- a/src/DataSet.h
+++ b/src/DataSet.h
@@ -58,7 +58,6 @@ class TabReader {
     if (pch == NULL) {
       err = 1;
     } else {
-      err = errno;
       advance(pch);
     }
   }
@@ -69,11 +68,12 @@ class TabReader {
   
   double readDouble() {
     char* next = NULL;
+    errno = 0;
     double d = strtod(f_, &next);
     if (next == f_) {
       err = 1;
     } else {
-      err = errno;
+      err = errno ? errno : err;
     }
     advance(next);
     return d;
@@ -81,11 +81,12 @@ class TabReader {
   
   int readInt() {
     char* next = NULL;
+    errno=0;
     int i = strtol(f_, &next, 10);
     if (next == f_) {
       err = 1;
     } else {
-      err = errno;
+      err = errno ? errno : err;
     }
     advance(next);
     return i;
@@ -97,7 +98,6 @@ class TabReader {
       err = 1;
       return std::string(f_);
     } else {
-      err = errno;
       std::string s(f_, pch - f_);
       advance(pch);
       return s;


### PR DESCRIPTION
There are no guarantees about `errno` when there is _no_ error. I ran into a situation where `errno==ENOMEM` on our system (for unknown reasons, unfortunately) which definately didn't come from `strtol()`.

It triggered the "your scan number is not an integer" error and percolator quit. This patch fixes the error handling for `strtol()` and we're not experiencing any problems with it anymore, however, I remain puzzled how `errno` was set to `ENOMEM` 🤷‍♂️ 