### PR TITLE
Changes to fix crux build

### DIFF
--- a/src/Caller.h
+++ b/src/Caller.h
@@ -45,6 +45,7 @@
 #include "CrossValidation.h"
 #include "Enzyme.h"
 
+#define  NO_BOOST_DATE_TIME_INLINE
 #include <boost/asio.hpp>
 #include <boost/functional/hash_fwd.hpp>
 

--- a/src/fido/CMakeLists.txt
+++ b/src/fido/CMakeLists.txt
@@ -12,7 +12,12 @@
 
 #add_library(fido STATIC ${FIDO_SOURCES})
 
+if(CRUX)
+  ADD_DEFINITIONS(-DCRUX)
+  include_directories(${PERCOLATOR_SOURCE_DIR}/src ${CRUX} ${CRUX}/src ${EXT_BINARY_DIR})
+else(CRUX)
 include_directories(${PERCOLATOR_SOURCE_DIR}/src)
+endif(CRUX)
 link_directories(${PERCOLATOR_SOURCE_DIR}/src)
 
 file(GLOB FIDO_SOURCES Set.cpp Vector.cpp Numerical.cpp Random.cpp BasicBigraph.cpp BasicGroupBigraph.cpp GroupPowerBigraph.cpp)


### PR DESCRIPTION
These are a couple of small changes needed to allow Crux to build using the percolator source.