### PR TITLE
Yang's mod

### DIFF
--- a/src/Caller.cpp
+++ b/src/Caller.cpp
@@ -342,6 +342,14 @@ bool Caller::parseOptions(int argc, char **argv) {
       "Q-value threshold that will be used in the computation of the MSE and ROC AUC score in the grid search. Recommended 0.05 for normal size datasets and 0.1 for large datasets. Default = 0.1",
       "value");
 
+
+  /// added by Yang
+  cmd.defineOption("TDMap",
+        "target-decoy-mapping",
+        "the filename to store the mapping between targets and decoys",
+        "filename");
+
+
   /* EXPERIMENTAL FLAGS: no long term support, flag names might be subject to change and behavior */
   cmd.defineOption(Option::EXPERIMENTAL_FEATURE,
       "num-threads",
@@ -677,6 +685,14 @@ bool Caller::parseOptions(int argc, char **argv) {
       return 0;
     }
   }
+
+  /// added by Yang
+  if (cmd.optionSet("target-decoy-mapping")) {
+	  targetDecoyMapURL = cmd.options["target-decoy-mapping"];
+	  std::cout << "-----------------------------------------------------------" << std::endl;
+	  std::cout << targetDecoyMapURL << std::endl;
+  }
+
 
   // If a static model is used, no nested CV is needed for Cpos and Cneg.
   // Also, their values don't matter.

--- a/src/Caller.h
+++ b/src/Caller.h
@@ -107,6 +107,11 @@ class Caller {
   void calculateProteinProbabilities(Scores& allScores);
   void checkIsWritable(const std::string& filePath);
   
+  /// added by Yang
+  std::string targetDecoyMapURL;
+
+
+
 #ifdef CRUX
   virtual void processPsmScores(Scores& allScores) {}
   virtual void processPeptideScores(Scores& allScores) {}

--- a/src/Scores.cpp
+++ b/src/Scores.cpp
@@ -359,7 +359,7 @@ void Scores::createXvalSetsBySpectrum(std::vector<Scores>& train,
 
     unsigned long pep_token = 1u;
     for (int char_idx=0; char_idx<unmod_pep.length(); ++char_idx) { pep_token += (int)unmod_pep.at(char_idx) * (1+char_idx); }
-//    std::cout << "peptide=" << sh.pPSM->getPeptideSequence() <<"\tunmod_pep="<< unmod_pep <<"\tpep_token="<< pep_token << std::endl;
+    if (mod_cnt > 0) std::cout << "peptide=" << sh.pPSM->getPeptideSequence() <<"\tunmod_pep="<< unmod_pep <<"\tpep_token="<< pep_token << std::endl;
 
     size_t randIndex = pep_token % xval_fold;
     foldcnt[randIndex] += 1;

--- a/src/Scores.cpp
+++ b/src/Scores.cpp
@@ -359,7 +359,7 @@ void Scores::createXvalSetsBySpectrum(std::vector<Scores>& train,
 
     unsigned long pep_token = 1u;
     for (int char_idx=0; char_idx<unmod_pep.length(); ++char_idx) { pep_token += (int)unmod_pep.at(char_idx) * (1+char_idx); }
-    if (mod_cnt > 0) std::cout << "peptide=" << sh.pPSM->getPeptideSequence() <<"\tunmod_pep="<< unmod_pep <<"\tpep_token="<< pep_token << std::endl;
+    //if (mod_cnt > 0) std::cout << "peptide=" << sh.pPSM->getPeptideSequence() <<"\tunmod_pep="<< unmod_pep <<"\tpep_token="<< pep_token << std::endl;
 
     size_t randIndex = pep_token % xval_fold;
     foldcnt[randIndex] += 1;


### PR DESCRIPTION
I am trying to make some modification to Percolator so that we ensure PSMs corresponding to the same target and decoy pair end up in the same split. The motivation of doing that is to guarantee more rigorous peptide-level "weed out then estimate" procedure in the sense that we want those PSMs to be normalized (i.e. merging cross-validation) in the same way.
What we did is very simple. For each peptide p, we calculate a peptide-specific token by ''{}{}_{}'.format(p[0], p[-1], sort(p)), that is, a concatenation of first amino acid, last amino acid, and the sorted peptide. For example, the token of PEPTIDE is PE_DEEIPPT. With this regard, both target and decoy will have the same token. Next, we calculate a position-aware token value by \sum{i=0}^{len(p)} (pos(i)+1) * ASCII(p[i]). For example, the token value for PE_DEEIPPT is calculated as ASCII(P) * 1+ ASCII(E) * 2+...+ASCII(T) * 10. Finally, the split assignment for each peptid is based on the token value mod 3. 