### PR TITLE
Added explicit linking to /usr/local/lib for MacOS.

### DIFF
--- a/src/converters/CMakeLists.txt
+++ b/src/converters/CMakeLists.txt
@@ -16,6 +16,10 @@ include("${PERCOLATOR_SOURCE_DIR}/CommonCMake.txt")
 ###############################################################################
 # PREPARING TO INSTALL
 ###############################################################################
+IF(APPLE)
+  # Fix linking on 10.14+. See https://stackoverflow.com/questions/54068035
+  LINK_DIRECTORIES(/usr/local/lib)
+ENDIF()
 
 my_set(CMAKE_BUILD_TYPE "Release" "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
 my_set(CMAKE_PREFIX_PATH "../" "Default path to packages")


### PR DESCRIPTION
This change is to fix the build process for MacOS. 

There's a useful discussion of why this is needed for MacOS >=10.14 (Mojave and newer) here: https://discourse.brew.sh/t/cmake-linking-not-working-since-mojave/3790/8