### PR TITLE
Fix the build instructions that installs GoogleTest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #############################################################################
 # NAME AND VERSION
 ###############################################################################
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.11)
 
 if(NOT CRUX AND APPLE AND ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.0)
   # Identify AppleClang's COMPILER_ID as AppleClang instead of just Clang 

--- a/data/unit_tests/percolator/CMakeLists.txt
+++ b/data/unit_tests/percolator/CMakeLists.txt
@@ -1,49 +1,44 @@
 
-# TODO(breadbox): Auto-install of googletest code needs to be updated.
-# USE THIS WHEN THE 1.5 VERSION OF GTEST WILL BE FINALLY SUPPORTED INSTEAD OF BUILDING IN INSTALL SCRIPT
-SET( BASE "/tmp")
-if(GOOGLE_TEST) ## DO IT IF ONLY IF GOOGLE TEST IS ACTIVATED
-  find_package(GoogleTest REQUIRED) 
-  if(NOT GTEST_FOUND)
-    SET( GT_SITE "http://googletest.googlecode.com/files")
-    SET( GT_PACK "gtest-1.6.0")
-    message( STATUS "Package Google Test has not been found, prodecing to download it")
-
-    execute_process(COMMAND wget -nc "${GT_SITE}/${GT_PACK}.zip" WORKING_DIRECTORY ${BASE} OUTPUT_VARIABLE output ERROR_VARIABLE error RESULT_VARIABLE rv)
-    execute_process(COMMAND unzip -o "${GT_PACK}.zip" WORKING_DIRECTORY ${BASE} OUTPUT_VARIABLE output ERROR_VARIABLE error RESULT_VARIABLE rv)
-    execute_process(COMMAND rm "${GT_PACK}.zip" WORKING_DIRECTORY ${BASE} OUTPUT_VARIABLE output ERROR_VARIABLE error RESULT_VARIABLE rv)
-
-    if(${rv} EQUAL 0) #installed okay
-      message(STATUS "GoogleTest has been downloaded succesfully : ${BASE}/${GT_PACK}")
-    else(${rv} EQUAL 0)
-      message(FATAL_ERROR "There has been a problem downloading the package.Error: '${error}")
-    endif(${rv} EQUAL 0)
-
-    message(STATUS "Installing GoogleTest")
-
-    execute_process(COMMAND cmake . WORKING_DIRECTORY "${BASE}/${GT_PACK}" OUTPUT_VARIABLE output ERROR_VARIABLE error RESULT_VARIABLE rv)
-    execute_process(COMMAND make WORKING_DIRECTORY "${BASE}/${GT_PACK}" OUTPUT_VARIABLE output ERROR_VARIABLE error RESULT_VARIABLE rv)
-    #TODO compile it properly and delete it after compiling
-    if(${rv} EQUAL 0) #compiled okay
-      set(GOOGLE_TEST_PATH "${BASE}/${GT_PACK}") ##set the variable accordingly
-      find_package(GoogleTest REQUIRED)
-      message(STATUS "GoogleTest has been installed succesfully ${GTEST_INCLUDE_DIRS}")
-      
-    else(${rv} EQUAL 0)
-      message(FATAL_ERROR "The package Google Test has not been found, you can download it and install it from :\n
-			  http://code.google.com/p/googletest/downloads/list .Alternatively you can run this instruction to install it\n
-			  under debian based systems : apt-get install google-gadgets-gtk (you must run it as sudo).")
-    endif(${rv} EQUAL 0)
-
-  else(NOT GTEST_FOUND)
-    message(STATUS "Package Google Test found: ${GTEST_INCLUDE_DIRS}")
-  endif(NOT GTEST_FOUND)
-
+# If GoogleTest is not installed, build and install a private copy.
+# Skip this step if GOOGLE_TEST is not defined.
+if(GOOGLE_TEST)
+  find_package(GoogleTest REQUIRED)
+  if(GTEST_FOUND)
+    message(STATUS "Using installed GoogleTest at: ${GTEST_INCLUDE_DIRS}")
+  else(GTEST_FOUND)
+    message(STATUS "GoogleTest package not found; proceeding to download it.")
+    configure_file(GTestExtProject.cmake.in googletest-download/CMakeLists.txt)
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+    if(result)
+      message(FATAL_ERROR "Failed to download GoogleTest: ${result}.")
+    endif()
+    message(STATUS "Building GoogleTest.")
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+      RESULT_VARIABLE result
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download)
+    if(result)
+      message(FATAL_ERROR "Failed to build GoogleTest package: ${result}.")
+    endif()
+    # Prevent overriding the parent project's compiler/linker
+    # settings on Windows
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    # Add googletest directly to our build. This defines
+    # the gtest and gtest_main targets.
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                     ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                     EXCLUDE_FROM_ALL)
+    set(GTEST_INCLUDE_DIRS "${gtest_SOURCE_DIR}/include")
+    message(STATUS "GoogleTest has been installed succesfully: ${GTEST_INCLUDE_DIRS}.")
+  endif(GTEST_FOUND)
 endif(GOOGLE_TEST)
 
-# LINING AND BUILDING GTEST
-include_directories (${GTEST_INCLUDE_DIRS} ${PERCOLATOR_SOURCE_DIR}/src ${PERCOLATOR_SOURCE_DIR}/src/fido ${PERCOLATOR_SOURCE_DIR}/data/tests ${CMAKE_BINARY_DIR}/src)
-add_executable (gtest_unit Unit_tests_Percolator_main.cpp)
-target_link_libraries (gtest_unit perclibrary ${GTEST_BOTH_LIBRARIES} pthread)
+# Linking and building unit tests
+include_directories(${GTEST_INCLUDE_DIRS} ${PERCOLATOR_SOURCE_DIR}/src ${PERCOLATOR_SOURCE_DIR}/src/fido ${PERCOLATOR_SOURCE_DIR}/data/tests ${CMAKE_BINARY_DIR}/src)
+add_executable(gtest_unit Unit_tests_Percolator_main.cpp)
+target_link_libraries(gtest_unit perclibrary gtest gtest_main pthread)
 add_test(UnitTest_Percolator_RunAllTests gtest_unit)
-install (TARGETS gtest_unit EXPORT PERCOLATOR DESTINATION ./bin) # Important to use relative path here (used by CPack)!
+
+# Important to use relative paths here (used by CPack)!
+install(TARGETS gtest_unit EXPORT PERCOLATOR DESTINATION ./bin)

--- a/data/unit_tests/percolator/GTestExtProject.cmake.in
+++ b/data/unit_tests/percolator/GTestExtProject.cmake.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+# Define an external project for GoogleTest.
+project(googletest-download NONE)
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)


### PR DESCRIPTION
Unlike the prior version, this code does not install gtest systemwide.
If gtest is not already present, a copy is installed within the cmake
build directory tree.