### PR TITLE
Link with the code to test, instead of duplicating it via #include.

### DIFF
--- a/data/unit_tests/percolator/CMakeLists.txt
+++ b/data/unit_tests/percolator/CMakeLists.txt
@@ -35,9 +35,15 @@ if(GOOGLE_TEST)
 endif(GOOGLE_TEST)
 
 # Linking and building unit tests
-include_directories(${GTEST_INCLUDE_DIRS} ${PERCOLATOR_SOURCE_DIR}/src ${PERCOLATOR_SOURCE_DIR}/src/fido ${PERCOLATOR_SOURCE_DIR}/data/tests ${CMAKE_BINARY_DIR}/src)
-add_executable(gtest_unit Unit_tests_Percolator_main.cpp)
-target_link_libraries(gtest_unit perclibrary gtest gtest_main pthread)
+include_directories(${GTEST_INCLUDE_DIRS}
+    ${PERCOLATOR_SOURCE_DIR}/src
+    ${PERCOLATOR_SOURCE_DIR}/src/fido
+    ${PERCOLATOR_SOURCE_DIR}/data/tests
+    ${CMAKE_BINARY_DIR}/src)
+add_executable(gtest_unit
+    Unit_tests_Percolator_main.cpp
+    UnitTest_Percolator_Fido.cpp)
+target_link_libraries(gtest_unit perclibrary fido gtest gtest_main pthread)
 add_test(UnitTest_Percolator_RunAllTests gtest_unit)
 
 # Important to use relative paths here (used by CPack)!

--- a/data/unit_tests/percolator/UnitTest_Percolator_Fido.cpp
+++ b/data/unit_tests/percolator/UnitTest_Percolator_Fido.cpp
@@ -21,11 +21,8 @@
 /* This file include test cases for the EludeCaller class */
 #include <gtest/gtest.h>
 
-#include "PackedVector.cpp"
-#include "PackedMatrix.cpp"
-#include "Set.cpp"
-#include "Numerical.cpp"
-#include "Vector.cpp"
+#include "PackedVector.h"
+#include "PackedMatrix.h"
 #include "BaseSpline.h"
 
 class FidoVectorTest : public ::testing::Test {

--- a/data/unit_tests/percolator/Unit_tests_Percolator_main.cpp
+++ b/data/unit_tests/percolator/Unit_tests_Percolator_main.cpp
@@ -22,8 +22,7 @@
  * Main file for Google Test
  * Just run all tests
  */
-
-#include "UnitTest_Percolator_Fido.cpp"
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
While duping the source code into the unit test binary can work for an imported library like fido's PackedVector, it's not a good strategy for the majority of the code base. Better to just link with the same objects as the percolator binary.