### PR TITLE
Using c++11, to avoid problems with updated github macos runner.

### DIFF
--- a/CommonCMake.txt
+++ b/CommonCMake.txt
@@ -131,6 +131,9 @@ set(Boost_ADDITIONAL_VERSIONS "1.46" "1.47.0" "1.47"
 # SET COMPILER OPTIONS
 ###############################################################################
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED YES)
+
 IF(APPLE)
   add_definitions(-Dxdr_uint16_t=xdr_u_int16_t -Dxdr_uint32_t=xdr_u_int32_t -Dxdr_uint64_t=xdr_u_int64_t)
   set(Boost_USE_MULTITHREADED ON) # macports can currently not install single threaded boost libraries


### PR DESCRIPTION
An updated macos runner for github actions seem to break the  build. I'll try to fix the problem by enforcing c++11.