### PR TITLE
Fix Set::reindexTo scope error for iter variable

### DIFF
--- a/src/Set.cpp
+++ b/src/Set.cpp
@@ -50,7 +50,8 @@ Set Set::reindexTo(const Set & base) {
   if (base.isEmpty())
     throw InvalidBaseException();
 
-  for (Set::Iterator iter = begin(), baseIter = base.begin(); iter != end() && baseIter != base.end(); ) {
+  Set::Iterator iter = begin(), baseIter = base.begin();
+  for (; iter != end() && baseIter != base.end(); ) {
     if ( *iter > *baseIter ) {
       baseIter++;
     } else if ( *iter == *baseIter ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability and code quality. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->