### PR TITLE
Changing PEP default option to be the score-based Ispline

### DIFF
--- a/src/Caller.cpp
+++ b/src/Caller.cpp
@@ -79,7 +79,7 @@ Caller::Caller()
       trainBestPositive_(false),
       numThreads_(3u), 
       useIrlsPep_(false),
-      useInterpolatingPep_(false),
+      useInterpolatingPep_(true),
       usePavaPep_(false) {}
 
 Caller::~Caller() {
@@ -392,9 +392,9 @@ bool Caller::parseOptions(int argc, char** argv) {
       "irls-pep",
       "Calculate PEPs using a cubic spline fitted using penalized log-likelihood fitting as described in PMID:18689838. This used to be the default method.",
       "", TRUE_IF_SET);
-  cmd.defineOption(Option::EXPERIMENTAL_FEATURE,
-      "ip-pep",
-      "Use scores instead of rank as independent variable when calculating PEPs.",
+  cmd.defineOption("",
+      "rank-pep",
+      "Use rank instead of score as independent variable when calculating PEPs.",
       "", TRUE_IF_SET);
   cmd.defineOption(Option::EXPERIMENTAL_FEATURE,
         "pava-pep",
@@ -509,8 +509,8 @@ bool Caller::parseOptions(int argc, char** argv) {
   if (cmd.isOptionSet("irls-pep")) {
     useIrlsPep_ = true;
   }
-  if (cmd.isOptionSet("ip-pep")) {
-    useInterpolatingPep_ = true;
+  if (cmd.isOptionSet("rank-pep")) {
+    useInterpolatingPep_ = false;
   }
   if (cmd.isOptionSet("pava-pep")) {
     usePavaPep_ = true;

--- a/src/Scores.h
+++ b/src/Scores.h
@@ -84,7 +84,7 @@ class Scores {
                          bool skipDecoysPlusOne = false);
   int calcScores(vector<double>& w);
   int calcQvals(double fdr, bool skipDecoysPlusOne = false);
-  void calcPep(const bool spline = false, const bool interpol = false, const bool from_q = false);
+  void calcPep(const bool spline = false, const bool interpol = true, const bool from_q = false);
  
   void populateWithPSMs(SetHandler& setHandler);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated default PEP calculation method to use interpolating approach for improved accuracy
  * Modified command-line option interface for rank-based PEP selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/percolator/percolator/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->